### PR TITLE
:rocket: add constructor attribute rule

### DIFF
--- a/changelog.d/constructor-attribute.added
+++ b/changelog.d/constructor-attribute.added
@@ -1,0 +1,1 @@
+add rule to prevent constructors being tagged as external (thanks to Antoine for his contribution)

--- a/rules/constructor-attribute.yaml
+++ b/rules/constructor-attribute.yaml
@@ -1,0 +1,10 @@
+rules:
+  - id: constructor-attribute
+    languages: [cairo]
+    message: "Constructors should not be tagged as #[external]. Use #[constructor] instead."
+    severity: ERROR
+    pattern: |
+      #[external]
+      fn constructor(...) {
+          ...
+      }

--- a/tests/constructor-attribute.cairo
+++ b/tests/constructor-attribute.cairo
@@ -1,0 +1,20 @@
+#[contract]
+mod contract {
+    // Storage
+    struct Storage {
+        // Some storage
+        var1: u256,
+    }
+
+    // ruleid: constructor-attribute
+    #[external]
+    fn constructor(init_var: u256) {
+        var1::write(init_var);
+    }
+    
+    // ok: constructor-attribute
+    #[external]
+    fn some_function(init_var: u256) {
+        var1::write(init_var);
+    }
+}


### PR DESCRIPTION
This PR adds a small rule that triggers an error when semgrep finds a constructor tagged as `#[external]`.

When a constructor doesn't have the attribute `#[constructor]` and is `#[external]`, it will be considered by the compiler as any external function. Hence, the contract is initialized properly and  anyone could call the constructor with arbitrary values.